### PR TITLE
Added initial Dockerfile for engine component

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
   "engine":{
-    "port":"",
+    "port":"7777",
     "debug":true,
     "cache_location":"",
     "book_location":""

--- a/engine/Dockerfile
+++ b/engine/Dockerfile
@@ -1,0 +1,17 @@
+FROM golang
+
+WORKDIR /go/src/engine
+ADD . /go/src/engine
+RUN go get gopkg.in/mgo.v2
+RUN go get gopkg.in/validator.v2
+RUN go get github.com/gorilla/mux
+RUN go get github.com/unrolled/render
+RUN go get github.com/thoas/stats
+RUN go get github.com/codegangsta/negroni
+RUN go get github.com/boltdb/bolt
+RUN go get github.com/briandowns/stock-exchange/database
+RUN go get github.com/pborman/uuid
+
+RUN go install engine
+EXPOSE 7777
+ENTRYPOINT /go/bin/engine


### PR DESCRIPTION
- Contains initial Dockerfile for `engine` component
- NOT OPTIMIZED yet but we can worry about reducing image layers later or utilizing `go-dep` or something else.
